### PR TITLE
Simplified and partially rewritten.

### DIFF
--- a/src/automata/core.clj
+++ b/src/automata/core.clj
@@ -2,12 +2,14 @@
   (:require [quil.core :as q]
             [quil.middleware :as m]))
 
-(defn make-row [n around middle]
-  (let [c (vec (take n (repeat around)))]
+(def constants {:scale 5})
+
+(defn make-row [{:keys [n around middle scale]}]
+  (let [c (vec (take (if scale (* scale n) n) (repeat around)))]
   (assoc c (/ (count c) 2) middle)))
 
 (def first-row
-  #(make-row 200 0 1))
+  #(make-row {:n 20 :around 0 :middle 1 :scale (constants :scale)}))
 
 (defn setup []
   ; Set frame rate to 30 frames per second.
@@ -16,7 +18,7 @@
   (q/color-mode :hsb)
   ; setup function returns initial state. It contains
   ; circle color and position.
-  {:cell-size 5
+  {:scale (constants :scale)
    :rule {
           [0 0 0] 0
           [0 0 1] 1
@@ -65,7 +67,7 @@
 
   (doseq [x (map-indexed vector (last (:cells state)))
           :let [y (:row state)
-                w (:cell-size state)]]
+                w (:scale state)]]
     (if (= 1 (last x))
       (q/rect (* w (first x)) (* w y) w w)))
 
@@ -79,7 +81,7 @@
 
 (q/defsketch automata
   :title "You spin my circle right round"
-  :size [500 500]
+  :size (vec (take 2 (repeat (* (constants :scale) 100))))
   ; setup function called only once, during sketch initialization.
   :setup setup
   ; update is called on each iteration before draw is called.

--- a/src/automata/core.clj
+++ b/src/automata/core.clj
@@ -2,61 +2,76 @@
   (:require [quil.core :as q]
             [quil.middleware :as m]))
 
-(def constants {:scale 5})
+(defn seed-row [hw]
+  "hw = number of 0s to pad on each side."
+  (concat (repeat hw 0) (conj (repeat hw 0) 1)))
 
-(defn make-row [{:keys [n around middle scale]}]
-  (let [c (vec (take (if scale (* scale n) n) (repeat around)))]
-  (assoc c (/ (count c) 2) middle)))
+(assert (= (seed-row 3) '(0 0 0 1 0 0 0)))
 
-(def first-row
-  #(make-row {:n 20 :around 0 :middle 1 :scale (constants :scale)}))
+
+
+;(defn neighbors [x]
+;  "Get's immediate neighbors on the x-axis"
+;  (for [dx [-1 1]]
+;    (+ dx x)))
+
+;(defn cell+neighbors [x]
+;  (for [dx [-1 0 1]]
+;    (+ dx x)))
+
+
+(defn generate-next [row rule]
+  (let [g (partition 3 1 row)]
+    ;(println "next " rule vec g (map vec g) (map rule (map vec g)))
+    (concat (concat [0] (map rule (map vec g))) [0])))
+
+(def rule30
+  "Not sure if this is idiomatic in Clojure, but everything's a function, right?"
+  {
+    [0 0 0] 0
+    [0 0 1] 1
+    [0 1 0] 1
+    [0 1 1] 1
+    [1 0 0] 1
+    [1 0 1] 0
+    [1 1 0] 0
+    [1 1 1] 0})
+
+
+(assert
+  (=
+    (generate-next (seed-row 5) rule30)
+    '(0 0 0 0 1 1 1 0 0 0 0)))
+
+(assert
+  (=
+    (generate-next (vec '(0 0 1 0 0 1 0 0 1)) rule30)
+    '(0 1 1 1 1 1 1 1 0)))
+
+
+;(defn mouse-clicked [state event]
+;  "Mouse handler to reset state"
+;  (q/background 240)
+;  (assoc state :row 0 :cells [(first-row)]))
+
 
 (defn setup []
   ; Set frame rate to 30 frames per second.
   (q/frame-rate 5)
   ; Set color mode to HSB (HSV) instead of default RGB.
   (q/color-mode :hsb)
-  ; setup function returns initial state. It contains
-  ; circle color and position.
-  {:scale (constants :scale)
-   :rule {
-          [0 0 0] 0
-          [0 0 1] 1
-          [0 1 0] 1
-          [0 1 1] 1
-          [1 0 0] 1
-          [1 0 1] 0
-          [1 1 0] 0
-          [1 1 1] 0} ; rule 30
-   :row 0
-   :cells [(first-row)]; y (row) implicit as index, x (cols) as value
-   })
-
-(defn neighbors [x]
-  "Get's immediate neighbors on the x-axis"
-  (for [dx [-1 1]]
-  (+ dx x)))
-
-(defn cell+neighbors [x]
-  (for [dx [-1 0 1]]
-  (+ dx x)))
-
-(defn generate-next [row rule]
-  (let [g (partition 3 1 row)]
-    (println "next " (map rule (map vec g)))
-    (map rule (map vec g)))
-  )
-
+  ; setup function returns initial state: row index and current cells
+  {
+    :row 0
+    :cells [(seed-row 20)]})  ; y (row) implicit as index, x (cols) as value
 
 (defn update [state]
   "Calculates next row in state"
   (let [cells (:cells state)
-        rule (:rule state)
-        next-row (generate-next (last cells) rule)]
-;;     (println "updating" (state :row))
-;;     (println "cells" (state :cells))
-
-    (assoc state :cells (conj cells (vec next-row)) :row (inc (:row state)))))
+        next-row (generate-next (last cells) rule30)]
+  (assoc state
+    :cells (conj cells (vec next-row))
+    :row (inc (:row state)))))
 
 (defn draw [state]
   "Draws current state"
@@ -67,21 +82,13 @@
 
   (doseq [x (map-indexed vector (last (:cells state)))
           :let [y (:row state)
-                w (:scale state)]]
+                w 20]]
     (if (= 1 (last x))
-      (q/rect (* w (first x)) (* w y) w w)))
-
-  ;(if (<= (:frame state) 117) (q/save-frame "frame-####.png"))
-  )
-
-(defn mouse-clicked [state event]
-  "Mouse handler to reset state"
-  (q/background 240)
-  (assoc state :row 0 :cells [(first-row)]))
+      (q/rect (* w (first x)) (* w y) w w))))
 
 (q/defsketch automata
   :title "You spin my circle right round"
-  :size (vec (take 2 (repeat (* (constants :scale) 100))))
+  :size (vec (take 2 (repeat (* 20 100))))
   ; setup function called only once, during sketch initialization.
   :setup setup
   ; update is called on each iteration before draw is called.


### PR DESCRIPTION
OK, so maybe more than partially. You were missing the edge condition (literally). Every time you map a row of triples to the next row the first and last values are lost. For example a 3-element row (0 1 0) might map to (1), but then you need to put something back in to pad it out to it's correct size (concat [0] intermediate-result [0]) or whatever.